### PR TITLE
[strformat] make file reads more selective

### DIFF
--- a/bin/strformat.py
+++ b/bin/strformat.py
@@ -7,7 +7,7 @@ kwargs = {}
 
 for arg in sys.argv[1:]:
     k, v = arg.split('=', maxsplit=1)
-    if os.path.exists(v):
+    if k == 'body' and os.path.isfile(v):
         v = open(v).read()
     kwargs[k] = v
 


### PR DESCRIPTION
I ran into an issue trying to run `bin/mkwww.sh` from my Mac. During the build [this line](https://github.com/saulpw/visidata.org/blob/master/bin/mkpage.sh#L10) gets called for a page where `title="VisiData"`. That causes `strformat.py` to try to read from `visidata/` because the `exists()` check is case-insensitive:

```
Traceback (most recent call last):
  File "/Users/akerrigan/code/visidata.org/bin/strformat.py", line 11, in <module>
    v = open(v).read()
IsADirectoryError: [Errno 21] Is a directory: 'VisiData'
```

I can work around the issue by turning `os.path.exists()` to `os.path.isfile()`, but based on how `strformat.py` gets called it may make more sense to only try a file read for the body parameter anyway.