### PR TITLE
Add instructions to install bleeding edge using Guix

### DIFF
--- a/site/install.md
+++ b/site/install.md
@@ -44,5 +44,10 @@ Install [brew](https://brew.sh) if necessary, and then run:
 
 ## Unreleased Bleeding Edge
 
+Using Pip:
+
     pip3 install git+https://github.com/saulpw/visidata.git@develop
 
+Using Guix:
+
+    guix install --without-tests=visidata --with-git-url=visidata=https://github.com/saulpw/visidata.git --with-branch=visidata=develop visidata


### PR DESCRIPTION
Like Pip, Guix can install the visidata develop branch if you give it the right transform flags. This PR adds those flags to the install instructions.